### PR TITLE
Add aria-expanded toggle for menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
         type="checkbox"
         id="menu-btn"
         aria-label="Menu toggle"
+        aria-expanded="false"
       />
       <label
         class="menu-icon"

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,16 @@ window.addEventListener('DOMContentLoaded', () => {
     yearEl.textContent = new Date().getFullYear();
   }
 
+  // Toggle aria-expanded on the mobile menu checkbox
+  const menuToggle = document.getElementById('menu-btn');
+  if (menuToggle) {
+    const setExpanded = () => {
+      menuToggle.setAttribute('aria-expanded', menuToggle.checked ? 'true' : 'false');
+    };
+    setExpanded();
+    menuToggle.addEventListener('change', setExpanded);
+  }
+
   // Animate article cards on scroll
   const observer = new IntersectionObserver((entries, obs) => {
     entries.forEach(entry => {


### PR DESCRIPTION
## Summary
- add `aria-expanded="false"` attribute to mobile menu checkbox
- update JS to keep aria-expanded in sync with menu state

## Testing
- `node -v` *(fails: command not found)*